### PR TITLE
Fixed Edit User Bug  #75

### DIFF
--- a/authsystem/update_user.php
+++ b/authsystem/update_user.php
@@ -25,14 +25,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($name) && !empty($email) && !empty($age)) {
         if((strtolower(trim($name)) !== strtolower(trim($namedb))) || (intval($age) !== intval($agedb)) || ($status !== $statusdb)){
             if (strtolower(trim($emaildb)) === strtolower(trim($email))) {
-                if($age >= 18 && $age < 120){
-                    $query = "UPDATE users SET name = ?, email = ?, age = ?, status = ? WHERE id = ?";
-                    $stmt = $db->prepare($query);
-                    $stmt->bind_param("ssiii", $name, $email, $age, $status, $id);
-                    $stmt->execute();
-                    $success .= 'Account wurde erfolgreich aktualisiert.';
+                if ($id !== $_SESSION['id'] && $status == $statusdb ){
+                    if($age >= 18 && $age < 120){
+                        $query = "UPDATE users SET name = ?, email = ?, age = ?, status = ? WHERE id = ?";
+                        $stmt = $db->prepare($query);
+                        $stmt->bind_param("ssiii", $name, $email, $age, $status, $id);
+                        $stmt->execute();
+                        $success .= 'Account wurde erfolgreich aktualisiert.';
+                    }else{
+                        $error .= 'Das Alter muss zwischen 18 und 120 Jahren liegen.';
+                    }
                 }else{
-                    $error .= 'Das Alter muss zwischen 18 und 120 Jahren liegen.';
+                    $error .= 'Der eigene Status kann nicht geändert werden.';
                 }
             }else{
                 $error .= 'Nutzer E-Mail Adresse kann nicht geändert werden.';


### PR DESCRIPTION
This pull request introduces a validation check in the `authsystem/update_user.php` file to ensure that users cannot change their own status. Additionally, it provides an error message when this condition is violated.

### Validation improvements:

* [`authsystem/update_user.php`](diffhunk://#diff-5132a4e05f893570ba57fe346e86fefdee68cd338e23b688ae796fce0bb9f1cbR28): Added a condition to prevent users from changing their own status (`$id !== $_SESSION['id'] && $status == $statusdb`).
* [`authsystem/update_user.php`](diffhunk://#diff-5132a4e05f893570ba57fe346e86fefdee68cd338e23b688ae796fce0bb9f1cbR38-R40): Included an error message, "Der eigene Status kann nicht geändert werden," to inform users when they attempt to change their own status.